### PR TITLE
Replace any IDs within the new `selected_fields` array

### DIFF
--- a/scripts/clone_organization.py
+++ b/scripts/clone_organization.py
@@ -807,6 +807,9 @@ if args.smart_views or args.all:
         elif query:
             smart_view['query'] = textual_replace(query, map_from_to_id)
 
+        # If user specifically selected some columns, replace IDs within those as well (in case they are custom fields)
+        smart_view['selected_fields'] = structured_replace(smart_view['selected_fields'], map_from_to_id)
+
         try:
             old_smart_view_id = smart_view.pop('id')
             del smart_view["organization_id"]


### PR DESCRIPTION
Saved columns per Smart View have been introduced, so we must update the `selected_fields` array with the replacement of any IDs (custom fields) on each Smart View. Otherwise, the cloning process will be unsuccessful because we will be attempting to create Smart Views using IDs that do not exist.